### PR TITLE
symeig -> eigvalsh

### DIFF
--- a/sparsecoding/inference.py
+++ b/sparsecoding/inference.py
@@ -415,8 +415,8 @@ class ISTA(InferenceMethod):
 
         # Calculate stepsize based on largest eigenvalue of
         # dictionary.T @ dictionary.
-        lipschitz_constant = torch.symeig(
-            torch.mm(dictionary.T, dictionary))[0][-1]
+        lipschitz_constant = torch.linalg.eigvalsh(
+            torch.mm(dictionary.T, dictionary))[-1]
         stepsize = 1. / lipschitz_constant
         self.threshold = stepsize * self.sparsity_penalty
 


### PR DESCRIPTION
avoids
```
sparsecoding/inference.py:441: UserWarning: torch.symeig is deprecated in favor of torch.linalg.eigh and will be removed in a future PyTorch release.
The default behavior has changed from using the upper triangular portion of the matrix by default to using the lower triangular portion.
L, _ = torch.symeig(A, upper=upper)
should be replaced with
L = torch.linalg.eigvalsh(A, UPLO='U' if upper else 'L')
and
L, V = torch.symeig(A, eigenvectors=True)
should be replaced with
L, V = torch.linalg.eigh(A, UPLO='U' if upper else 'L') (Triggered internally at  ../aten/src/ATen/native/BatchLinearAlgebra.cpp:2524.)
  lipschitz_constant = torch.symeig(
.......................
```