### PR TITLE
fix installation command for rtd

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ build:
   jobs:
     post_install:
       - sphinx-apidoc -M -o docs/generated sparsecoding
-      - pip install -r requirements.txt
+      - pip install ".[all]"
 
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
Recently merged documentation PR #84 contained incorrect installation command causing readthedocs to fail.